### PR TITLE
Fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Advection Corrected Correlation Image Velocimetry (ACCIV)
+
+ACCIV is a software that can be used to construct velocity fields from
+time-separated image data, with a particular focus on planetary-science
+applications. ACCIV is described in
+[Asay-Davis et al. (2009)](http://dx.doi.org/10.1016/j.icarus.2009.05.001).
+
+[Documentation and Tutorials](https://github.com/xylar/acciv/wiki)
+

--- a/acciv/ACCIVPass.cpp
+++ b/acciv/ACCIVPass.cpp
@@ -19,11 +19,6 @@
 #include <cstdlib>
 #include <algorithm>
 
-SInt32 lround(float x)
-{
-	SInt32 sign = (x > 0) ? 1 : ((x < 0) ? -1 : 0);
-	return sign*((SInt32)(fabs(x) + 0.5));
-}
 
 bool ACCIVPass::doPass(const UString & inFolder)
 {
@@ -368,7 +363,7 @@ bool ACCIVPass::getGridInfo()
 	imageBounds[1] = gridVelocityScaling.getXUpper();
 	imageBounds[2] = gridVelocityScaling.getYLower();
 	imageBounds[3] = gridVelocityScaling.getYUpper();
-	
+
 	return true;
 }
 
@@ -832,7 +827,7 @@ bool ACCIVPass::combineTiePoints()
 
 	for(SInt32 pairIndex = 0; pairIndex < imagePairs.getSize(); pairIndex += 2)
 	{
-		UString fileName = UString::makeFormat(correlationTiePointTemplate, 
+		UString fileName = UString::makeFormat(correlationTiePointTemplate,
 			earlierImageIndices[imagePairs[pairIndex]],
 			laterImageIndices[imagePairs[pairIndex+1]]);
 		TiePointSet tiePoints;
@@ -992,7 +987,7 @@ bool ACCIVPass::constructGridVelocityFromScatteredVelocity(const UString & inOut
 		return false;
 
 	VectorField2D gridVelocity(imageSize[0], imageSize[1], imageBounds[0], imageBounds[1], imageBounds[2], imageBounds[3]);
-	
+
 	meanRes = 0.0;
 
 	scatteredVelocity.smoothFit(gridVelocity, minControlPointScatteredNeighbors, outResiduals, meanRes);
@@ -1204,7 +1199,7 @@ bool ACCIVPass::appendOneSigmaUncertainty(const UArray<vector2d> & residuals,
 	gridVelocityScaling.interpolate(scatteredVelocity.getX(),scatteredVelocity.getY(), vScale);
 
 	printf("  smooth fit RMS one-sigma uncertainty: %g\n", meanResidual);
-	
+
 	hid_t fileID = H5Fopen(inOutScatteredVelocityFileName, H5F_ACC_RDWR, H5P_DEFAULT);
 	if(fileID < 0)
 	{
@@ -1424,7 +1419,7 @@ bool ACCIVPass::appendCorrelationUncertainties()
 	rmsVelocityRes = sqrt(rmsVelocityRes/(double)velocityPointCount);
 	printf("  RMS correlation location uncertainty: %g\n", rmsLocationRes);
 	printf("  RMS correlation velocity uncertainty: %g\n", rmsVelocityRes);
-	
+
 	hid_t fileID = H5Fopen(combinedTiePointsFileName, H5F_ACC_RDWR, H5P_DEFAULT);
 	if(fileID < 0)
 	{
@@ -1459,7 +1454,7 @@ bool ACCIVPass::appendCorrelationUncertainties()
 	status = H5LTmake_dataset(fileID, dataSetName, 1, dimensions, H5T_NATIVE_DOUBLE, correlationLocationRes.getData());
 	if((status < 0))
 	{
-		fprintf(stderr, "CCIVPass::appendCorrelationUncertainties: Could not make dataset %s in file %s\n", 
+		fprintf(stderr, "CCIVPass::appendCorrelationUncertainties: Could not make dataset %s in file %s\n",
 			(const char *)dataSetName, (const char *)combinedTiePointsFileName);
 		return false;
 	}
@@ -1469,7 +1464,7 @@ bool ACCIVPass::appendCorrelationUncertainties()
 	status = H5LTmake_dataset(fileID, dataSetName, 1, dimensions, H5T_NATIVE_DOUBLE, correlationVelocityRes.getData());
 	if((status < 0))
 	{
-		fprintf(stderr, "CCIVPass::appendCorrelationUncertainties: Could not make dataset %s in file %s\n", 
+		fprintf(stderr, "CCIVPass::appendCorrelationUncertainties: Could not make dataset %s in file %s\n",
 			(const char *)dataSetName, (const char *)combinedTiePointsFileName);
 		return false;
 	}
@@ -1567,7 +1562,7 @@ bool ACCIVPass::removeOutliers(const UArray<vector2d> & residuals,
 	TiePointSet oldTiePoints, newTiePoints;
 	if(!oldTiePoints.read(inTiePointsFileName))
 		return false;
-	
+
 	SInt32 removedCount = 0;
 	// for each value of deltaT
 	for(SInt32 timeIndex = 0; timeIndex < oldTiePoints.getDeltaTs().getSize(); timeIndex++)
@@ -1613,7 +1608,7 @@ bool ACCIVPass::removeOutliers(const UArray<vector2d> & residuals,
 	// save the new tie points
 	if(!newTiePoints.write(outTiePointsFileName))
 		return false;
-	
+
 	return true;
 }
 

--- a/acciv/Utility/core/UString.cpp
+++ b/acciv/Utility/core/UString.cpp
@@ -106,7 +106,7 @@ UString UString::operator=( const UString& inString )
 UString UString::operator=( const char* inString )
 {
 	UInt32 length = strlen( inString );
-	
+
 	assureDataAvailable( length );
 	assureDataModifiable();
 
@@ -134,7 +134,7 @@ UString UString::operator+=( const char* inString )
 	UInt32 otherLength = strlen(inString);
 	assureDataAvailable( length + otherLength );
 	assureDataModifiable();
-	
+
 	memcpy( getDataBuffer() + length, inString, otherLength );
 	setDataLength( length + otherLength );
 	return *this;
@@ -361,7 +361,7 @@ void UString::insert( UInt32 inIndex, char inCharacter )
 {
 	UInt32 length = getLength();
 	U_ASSERT(inIndex <= length);
-	
+
 	length++;
 	assureDataAvailable(length);
 	assureDataModifiable();
@@ -636,7 +636,7 @@ void UString::trimLeft( const char* inCharacterSet )
 
 	char * buffer = getDataBuffer();
 
-	while(buffer != '\0')
+	while(*buffer != '\0')
 	{
 		if(strchr(inCharacterSet, *buffer) == NULL)
 			break;
@@ -776,7 +776,7 @@ void UString::split2( UString& dst1, UString& dst2, char separator ) const
 		int spaceIndex = tmp.find(' ');
 		if( tabIndex == -1 )
 			splitIndex = spaceIndex;
-		else if( spaceIndex == -1 ) 
+		else if( spaceIndex == -1 )
 			splitIndex = tabIndex;
 		else
 			splitIndex = spaceIndex < tabIndex ? spaceIndex : tabIndex;
@@ -897,7 +897,7 @@ void UString::reallocateData( UInt32 inStringLength )
 	newData->stringLength = std::min( inStringLength, getDataLength() );
 
 	memcpy( (char*)(newData+1), getDataBuffer(), newData->stringLength );
-	
+
 	setData( newData );
 	setDataLength( newData->stringLength );
 }


### PR DESCRIPTION
Fix a bug where a string buffer pointer is compared with `\0` instead of the buffer value.

Remove the definition of the function `lround`, which is included in `math.h`.